### PR TITLE
fix: use type for now expr if available

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -1458,7 +1458,7 @@ defmodule AshSql.Expr do
        ) do
     do_dynamic_expr(
       query,
-      %Ash.Query.Function.Type{arguments: [DateTime.utc_now(), :datetime, []]},
+      %Ash.Query.Function.Type{arguments: [DateTime.utc_now(), type || :datetime, []]},
       bindings,
       embedded? || pred_embedded?,
       acc,


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This very simple change uses the type if not `nil` in the `Now` expr, which solves the problem of using a specialized type like `:timstamptz` that has different behavior than `:datetime`.

All tests pass on `AshPostgres` with this change.