### PR TITLE
fix: use SQL standard = instead of non standard ==

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -1001,7 +1001,7 @@ defmodule AshSql.Expr do
               arguments: [
                 raw: "CASE WHEN (",
                 casted_expr: left_expr,
-                raw: " == FALSE OR ",
+                raw: " = FALSE OR ",
                 casted_expr: left_expr,
                 raw: " IS NULL) THEN ",
                 casted_expr: right_expr,
@@ -1051,7 +1051,7 @@ defmodule AshSql.Expr do
               arguments: [
                 raw: "CASE WHEN (",
                 casted_expr: left_expr,
-                raw: " == FALSE OR ",
+                raw: " = FALSE OR ",
                 casted_expr: left_expr,
                 raw: " IS NULL) THEN ",
                 casted_expr: left_expr,


### PR DESCRIPTION
Currently, some dynamic expressions (with `||` and `&&`) build non-standard SQL that uses `== FALSE` instead of `= FALSE`. MySQL does not support that and therefore I need that fix for my preliminary ash_mysql module (https://github.com/lejoko/ash_mysql). I would have happily added tests, but there are no tests at all in ash_sql... I manually tested those change both with ash_postgres and ash_sqlite and their tests seem fine with it.