### PR TITLE
fix: use period notation to access aggregate context fields

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -720,7 +720,7 @@ defmodule AshSql.Aggregate do
             expression =
               Ash.Expr.fill_template(
                 expression,
-                aggregate.context[:actor],
+                aggregate.context.actor,
                 %{},
                 aggregate.context
               )

--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -1265,10 +1265,10 @@ defmodule AshSql.Expr do
         ref =
           Ash.Actions.Read.add_calc_context_to_filter(
             ref,
-            aggregate.context[:actor],
-            aggregate.context[:authorize?],
-            aggregate.context[:tenant],
-            aggregate.context[:tracer],
+            aggregate.context.actor,
+            aggregate.context.authorize?,
+            aggregate.context.tenant,
+            aggregate.context.tracer,
             nil
           )
 


### PR DESCRIPTION
In some circumstances, the aggregate context is a struct and so we cannot use bracket notation. Using period notation works when the context is either a struct or a map. I noticed this is while upgrading one of my projects to ash 3. I wasn't able to reproduce it in an `ash_postgres` test, however it's occurring in my codebase. This change does not break any tests in the `ash_postgres` test suite when it's configured to use this patched `ash_sql`.