### PR TITLE
fix(count): use asterisk if not distinct by field is given

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -1630,10 +1630,13 @@ defmodule AshSql.Aggregate do
     field =
       case kind do
         :count ->
-          if Map.get(aggregate, :uniq?) do
-            Ecto.Query.dynamic([row], count(^field, :distinct))
-          else
-            Ecto.Query.dynamic([row], count())
+          cond do
+            Map.get(aggregate, :uniq?) ->
+              Ecto.Query.dynamic([row], count(^field, :distinct))
+            Ash.Resource.Info.field(resource, Ash.Query.Ref.name(ref)).allow_nil? ->
+              Ecto.Query.dynamic([row], count(^field))
+            true ->
+              Ecto.Query.dynamic([row], count())
           end
 
         :sum ->

--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -1633,10 +1633,10 @@ defmodule AshSql.Aggregate do
           cond do
             Map.get(aggregate, :uniq?) ->
               Ecto.Query.dynamic([row], count(^field, :distinct))
-            Ash.Resource.Info.field(resource, Ash.Query.Ref.name(ref)).allow_nil? ->
-              Ecto.Query.dynamic([row], count(^field))
-            true ->
+            match?(%{attribute: %{allow_nil?: false}}, ref) ->
               Ecto.Query.dynamic([row], count())
+            true ->
+              Ecto.Query.dynamic([row], count(^field))
           end
 
         :sum ->

--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -1633,7 +1633,7 @@ defmodule AshSql.Aggregate do
           if Map.get(aggregate, :uniq?) do
             Ecto.Query.dynamic([row], count(^field, :distinct))
           else
-            Ecto.Query.dynamic([row], count(^field))
+            Ecto.Query.dynamic([row], count())
           end
 
         :sum ->


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Hi @zachdaniel 

There is no value in using count(^field) in this case or am I wrong? We use the ash framework in a project with millions of entries. If we use count(*) instead of count(^field) (for example for the offset pagination), the time for the count action goes down from > 1sec to a couple of milliseconds.