### PR TITLE
Send context to default_bindings call in ash_sql query.ex

### DIFF
--- a/lib/query.ex
+++ b/lib/query.ex
@@ -172,7 +172,8 @@ defmodule AshSql.Query do
              |> Map.put(:offset, query.offset)
              |> AshSql.Bindings.default_bindings(
                resource,
-               query.__ash_bindings__.sql_behaviour
+               query.__ash_bindings__.sql_behaviour,
+               query.__ash_bindings__.context
              )
              |> Map.update!(:__ash_bindings__, fn bindings ->
                Map.merge(


### PR DESCRIPTION
This PR possibly fixes https://github.com/ash-project/ash/issues/1587 

I'm not sure if this breaks something else since this project doesn't have tests so I'm not sure how to test it.

Also, the same file has other calls to `AshSql.Bindings.default_bindings` without sending the `context` to it, but I'm not sure if they would reset the context in other places because of that or not.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
