### PR TITLE
fix: handle resource aggregate with function default in sort

### DIFF
--- a/lib/sort.ex
+++ b/lib/sort.ex
@@ -270,7 +270,13 @@ defmodule AshSql.Sort do
                     end
 
                   default_value =
-                    aggregate.default || Ash.Query.Aggregate.default_value(aggregate.kind)
+                    if is_function(aggregate.default) do
+                      aggregate.default.()
+                    else
+                      aggregate.default
+                    end
+
+                  default_value = default_value || Ash.Query.Aggregate.default_value(aggregate.kind)
 
                   if is_nil(default_value) do
                     Ecto.Query.dynamic(field(as(^binding), ^sort))


### PR DESCRIPTION
`default` of resource aggregate (unlike query aggregate's `default_value`) can be a function and need to be resolved before usage.