### PR TITLE
fix: use modified query instead of original when calling add_single_aggs when running aggregate query

### DIFF
--- a/lib/aggregate_query.ex
+++ b/lib/aggregate_query.ex
@@ -77,7 +77,7 @@ defmodule AshSql.AggregateQuery do
               repo.one(query, AshSql.repo_opts(repo, implementation, nil, nil, resource))
           end
 
-        {:ok, add_single_aggs(result, resource, original_query, cant_group, implementation)}
+        {:ok, add_single_aggs(result, resource, query, cant_group, implementation)}
     end
   end
 


### PR DESCRIPTION
Related to [#1472](https://github.com/ash-project/ash/issues/1472)
I figured out that this change makes `count` take in account distinct. 🎉 
Seems alright but I can never be sure, maybe it affects something else.? 😅

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
