### PR TITLE
fix: add ash bindings to modified query

### DIFF
--- a/lib/aggregate_query.ex
+++ b/lib/aggregate_query.ex
@@ -77,6 +77,7 @@ defmodule AshSql.AggregateQuery do
               repo.one(query, AshSql.repo_opts(repo, implementation, nil, nil, resource))
           end
 
+        query = Map.put(query, :__ash_bindings__, original_query.__ash_bindings__)
         {:ok, add_single_aggs(result, resource, query, cant_group, implementation)}
     end
   end


### PR DESCRIPTION
Test `test/aggregate_test.exs:1377` was failing:
```
  1) test sum a count with a limit and a filter can be aggregated at the query level (AshSql.AggregateTest)
     test/aggregate_test.exs:1377
     ** (KeyError) key :__ash_bindings__ not found in: #Ecto.Query<from p0 in subquery(from p0 in AshPostgres.Test.Post,
       as: 0,
       limit: ^1),
      as: 0, select: %{}>
     code: |> Ash.count!()
     stacktrace:
       (ash_sql 0.2.51) lib/join.ex:204: AshSql.Join.join_parent_paths/3
       (ash_sql 0.2.51) lib/join.ex:79: AshSql.Join.join_all_relationships/10
       (ash_sql 0.2.51) lib/filter.ex:10: AshSql.Filter.filter/4
       (ash_sql 0.2.51) lib/aggregate_query.ex:126: anonymous fn/5 in AshSql.AggregateQuery.add_single_aggs/5
       (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ash_sql 0.2.51) lib/aggregate_query.ex:81: AshSql.AggregateQuery.run_aggregate_query/4
       (ash 3.4.62) lib/ash/actions/aggregate.ex:91: anonymous fn/5 in Ash.Actions.Aggregate.run/4
       (elixir 1.18.1) lib/enum.ex:4964: Enumerable.List.reduce/3
       (elixir 1.18.1) lib/enum.ex:2600: Enum.reduce_while/3
       (ash 3.4.62) lib/ash.ex:940: Ash.aggregate/3
       (ash 3.4.62) lib/ash.ex:971: Ash.count/2
       (ash 3.4.62) lib/ash.ex:956: Ash.count!/2
       test/aggregate_test.exs:1390: (test)
```
because of the change made in #94 the modified query does not have `__ash_bindings__` in this case.
This solves the issue but not sure if 💯 correct approach.
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
