### PR TITLE
fix: pass correct operation to split_statements

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -3059,7 +3059,7 @@ defmodule AshSql.Expr do
   def split_statements(nil, _op), do: []
 
   def split_statements([left, right | rest], op) do
-    split_statements([%BooleanExpression{op: :and, left: left, right: right} | rest], op)
+    split_statements([%BooleanExpression{op: op, left: left, right: right} | rest], op)
   end
 
   def split_statements([last], op), do: split_statements(last, op)


### PR DESCRIPTION
Investigating a regression in our project seemingly introduced in https://github.com/ash-project/ash_sql/commit/71090b7fee0820abace34adf640d0cb9adee1b15. This line appears to be the culprit, since sometimes `split_statements` is called with `:or` instead of `:and`

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
