### PR TITLE
fix(expr): verify expression exists before handing to hydrate_refs

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -1498,8 +1498,14 @@ defmodule AshSql.Expr do
         List.wrap(bindings[:refs_at_path]) ++ relationship_path
       )
 
+    expression = if calculation.module.has_expression? do
+      calculation.module.expression(calculation.opts, calculation.context)
+    else
+      nil
+    end 
+
     case Ash.Filter.hydrate_refs(
-           calculation.module.expression(calculation.opts, calculation.context),
+           expression,
            %{
              resource: resource,
              aggregates: %{},


### PR DESCRIPTION
While using `ash_graphql`'s union feature, and updating a resource that contained a `calculation` would cause the underlying `ash_sql` to hit an error attempting to call `expression/2` on my calculation when none was defined. 

The defaults are incredible and cover all of my use cases so far. I'm not sure this is the correct fix and is more a reflection of my continued skills issue after attempting every permutation of implementing `expression/2` myself.

Here is an example of the error log using
ash: 3.5.34
ash_sql: 0.2.84
ash_graphql: 1.4.41

<details>
<summary>My error log</summary>

```
[warning] `265a6e2d-3c3b-4fc8-adf5-a9dd7c3b49f3`: AshGraphql.Error not implemented for error:

** (Ash.Error.Unknown) 
Bread Crumbs:
  > Exception raised in bulk update: MyApp.Foo.update

Unknown Error

* ** (UndefinedFunctionError) function MyApp.Foo.WorkInstructions.Calculations.GetWorkInstruction.expression/2 is undefined or private
  (sojourner 0.1.0) MyApp.Foo.MyUnion.Calculations.GetWorkInstruction.expression([], %Ash.Resource.Calculation.Context{actor: nil, tenant: nil, authorize?: nil, tracer: nil, domain: nil, resource: nil, type: MyApp.Foo.MyUnion.WorkInstruction, constraints: [types: [error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.ErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], data_collection: [constraints: [instance_of: MyApp.Foo.MyUnion.DataCollection, preserve_nil_values?: false], type: Ash.Type.Struct], fed_error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.FedErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], media: [constraints: [instance_of: MyApp.Foo.MyUnion.Media, preserve_nil_values?: false], type: Ash.Type.Struct], genealogy: [constraints: [instance_of: MyApp.Foo.MyUnion.Genealogy, preserve_nil_values?: false], type: Ash.Type.Struct], scan_check: [constraints: [instance_of: MyApp.Foo.MyUnion.ScanCheck, preserve_nil_values?: false], type: Ash.Type.Struct], step_check: [constraints: [instance_of: MyApp.Foo.MyUnion.StepCheck, preserve_nil_values?: false], type: Ash.Type.Struct], tcm_error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.TcmErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], validate_serial_number: [constraints: [instance_of: MyApp.Foo.MyUnion.ValidateSerialNumber, preserve_nil_values?: false], type: Ash.Type.Struct], web_api: [constraints: [instance_of: MyApp.Foo.MyUnion.WebApi, preserve_nil_values?: false], type: Ash.Type.Struct], web_equipment_response: [constraints: [instance_of: MyApp.Foo.MyUnion.WebEquipmentResponse, preserve_nil_values?: false], type: Ash.Type.Struct], torque: [constraints: [instance_of: MyApp.Foo.MyUnion.Torque, preserve_nil_values?: false], type: Ash.Type.Struct]], storage: :type_and_value, include_source?: false], arguments: %{}, source_context: %{}})
  (ash_sql 0.2.89) lib/expr.ex:1502: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/expr.ex:128: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/expr.ex:107: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/expr.ex:1120: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/expr.ex:714: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/expr.ex:1851: AshSql.Expr.default_dynamic_expr/6
  (ash_sql 0.2.89) lib/atomics.ex:39: anonymous fn/3 in AshSql.Atomics.select_atomics/3
  (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
  (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
  (ash_sql 0.2.89) lib/atomics.ex:14: AshSql.Atomics.select_atomics/3
  (ash_postgres 2.6.14) lib/data_layer.ex:1703: AshPostgres.DataLayer.bulk_updatable_query/6
  (ash_postgres 2.6.14) lib/data_layer.ex:1504: AshPostgres.DataLayer.update_query/4
  (ash 3.5.34) lib/ash/actions/update/bulk.ex:608: Ash.Actions.Update.Bulk.do_atomic_update/5
  (sojourner 0.1.0) lib/sojourner/repo.ex:2: anonymous fn/1 in MyApp.Repo."transaction (overridable 1)"/2
  (ecto 3.13.2) lib/ecto/repo/transaction.ex:7: anonymous fn/2 in Ecto.Repo.Transaction.transact/4
  (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
  (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4
  (ash 3.5.34) lib/ash/actions/update/bulk.ex:276: Ash.Actions.Update.Bulk.run/6
  (ash_graphql 1.7.17) lib/graphql/resolver.ex:1635: AshGraphql.Graphql.Resolver.mutate/2
    (sojourner 0.1.0) MyApp.Foo.MyUnion.Calculations.GetWorkInstruction.expression([], %Ash.Resource.Calculation.Context{actor: nil, tenant: nil, authorize?: nil, tracer: nil, domain: nil, resource: nil, type: MyApp.Foo.MyUnion.WorkInstruction, constraints: [types: [error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.ErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], data_collection: [constraints: [instance_of: MyApp.Foo.MyUnion.DataCollection, preserve_nil_values?: false], type: Ash.Type.Struct], fed_error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.FedErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], media: [constraints: [instance_of: MyApp.Foo.MyUnion.Media, preserve_nil_values?: false], type: Ash.Type.Struct], genealogy: [constraints: [instance_of: MyApp.Foo.MyUnion.Genealogy, preserve_nil_values?: false], type: Ash.Type.Struct], scan_check: [constraints: [instance_of: MyApp.Foo.MyUnion.ScanCheck, preserve_nil_values?: false], type: Ash.Type.Struct], step_check: [constraints: [instance_of: MyApp.Foo.MyUnion.StepCheck, preserve_nil_values?: false], type: Ash.Type.Struct], tcm_error_proofing: [constraints: [instance_of: MyApp.Foo.MyUnion.TcmErrorProofing, preserve_nil_values?: false], type: Ash.Type.Struct], validate_serial_number: [constraints: [instance_of: MyApp.Foo.MyUnion.ValidateSerialNumber, preserve_nil_values?: false], type: Ash.Type.Struct], web_api: [constraints: [instance_of: MyApp.Foo.MyUnion.WebApi, preserve_nil_values?: false], type: Ash.Type.Struct], web_equipment_response: [constraints: [instance_of: MyApp.Foo.MyUnion.WebEquipmentResponse, preserve_nil_values?: false], type: Ash.Type.Struct], torque: [constraints: [instance_of: MyApp.Foo.MyUnion.Torque, preserve_nil_values?: false], type: Ash.Type.Struct]], storage: :type_and_value, include_source?: false], arguments: %{}, source_context: %{}})
    (ash_sql 0.2.89) lib/expr.ex:1502: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/expr.ex:128: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/expr.ex:107: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/expr.ex:1120: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/expr.ex:714: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/expr.ex:1851: AshSql.Expr.default_dynamic_expr/6
    (ash_sql 0.2.89) lib/atomics.ex:39: anonymous fn/3 in AshSql.Atomics.select_atomics/3
    (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
    (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
    (ash_sql 0.2.89) lib/atomics.ex:14: AshSql.Atomics.select_atomics/3
    (ash_postgres 2.6.14) lib/data_layer.ex:1703: AshPostgres.DataLayer.bulk_updatable_query/6
    (ash_postgres 2.6.14) lib/data_layer.ex:1504: AshPostgres.DataLayer.update_query/4
    (ash 3.5.34) lib/ash/actions/update/bulk.ex:608: Ash.Actions.Update.Bulk.do_atomic_update/5
    (sojourner 0.1.0) lib/sojourner/repo.ex:2: anonymous fn/1 in MyApp.Repo."transaction (overridable 1)"/2
    (ecto 3.13.2) lib/ecto/repo/transaction.ex:7: anonymous fn/2 in Ecto.Repo.Transaction.transact/4
    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4
    (ash 3.5.34) lib/ash/actions/update/bulk.ex:276: Ash.Actions.Update.Bulk.run/6
    (ash_graphql 1.7.17) lib/graphql/resolver.ex:1635: AshGraphql.Graphql.Resolver.mutate/2
```

<details>

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
