### PR TITLE
Support calling immutable version of `ash_raise_error`

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -2080,29 +2080,51 @@ defmodule AshSql.Expr do
         {Jason.encode!(%{exception: inspect(exception), input: Map.new(input)}), acc}
       end
 
-    if type do
-      # This is a type hint, if we're raising an error, we tell it what the value
-      # type *would* be in this expression so that we can return a "NULL" of that type
-      # its weird, but there isn't any other way that I can tell :)
-      validate_type!(query, type, value)
-
-      type =
-        parameterized_type(
-          bindings.sql_behaviour,
-          type,
-          [],
-          :expr
-        )
-
+    dynamic_type =
       if type do
-        dynamic = Ecto.Query.dynamic(type(fragment("NULL"), ^type))
+        # This is a type hint, if we're raising an error, we tell it what the value
+        # type *would* be in this expression so that we can return a "NULL" of that type
+        # its weird, but there isn't any other way that I can tell :)
+        validate_type!(query, type, value)
 
-        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb, ?)", ^encoded, ^dynamic)), acc}
+        type =
+          parameterized_type(
+            bindings.sql_behaviour,
+            type,
+            [],
+            :expr
+          )
+
+        Ecto.Query.dynamic(type(fragment("NULL"), ^type))
       else
-        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb)", ^encoded)), acc}
+        nil
       end
-    else
-      {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb)", ^encoded)), acc}
+
+    # A row-dependent token for immutable calls, or nil if immutable_expr_error is not opted-in to.
+    row_token = immutable_error_expr_token(query, bindings)
+
+    case {dynamic_type, row_token} do
+      {nil, nil} ->
+        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb)", ^encoded)), acc}
+
+      {dynamic_type, nil} ->
+        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb, ?)", ^encoded, ^dynamic_type)),
+         acc}
+
+      {nil, row_token} ->
+        {Ecto.Query.dynamic(
+           fragment("ash_raise_error_immutable(?::jsonb, ?)", ^encoded, ^row_token)
+         ), acc}
+
+      {dynamic_type, row_token} ->
+        {Ecto.Query.dynamic(
+           fragment(
+             "ash_raise_error_immutable(?::jsonb, ?, ?)",
+             ^encoded,
+             ^dynamic_type,
+             ^row_token
+           )
+         ), acc}
     end
   end
 
@@ -3239,6 +3261,51 @@ defmodule AshSql.Expr do
       {query.__ash_bindings__.sql_behaviour.type_expr(expr, type), acc}
     else
       {expr, acc}
+    end
+  end
+
+  # Returns a row-dependent token to prevent constant-folding for immutable functions, or nil if
+  # the repo hasn't opted-in to immutable expr_errors.
+  #
+  # The expression doesn't matter, as long as it depends on the row to avoid constant-folding.
+  defp immutable_error_expr_token(query, bindings) do
+    resource = query.__ash_bindings__.resource
+    repo_config = query.__ash_bindings__.sql_behaviour.repo(resource, :read).config()
+
+    if Keyword.get(repo_config, :immutable_expr_error?, false) do
+      ref_binding = bindings.root_binding
+
+      pk_attr_names = Ash.Resource.Info.primary_key(resource)
+
+      attr_names =
+        case pk_attr_names do
+          [] ->
+            case Ash.Resource.Info.attributes(resource) do
+              [%{name: name} | _] -> [name]
+              _ -> []
+            end
+
+          pk ->
+            pk
+        end
+
+      if ref_binding && attr_names != [] do
+        Enum.reduce(attr_names, Ecto.Query.dynamic(fragment("''::text")), fn attr_name, acc ->
+          value_expr =
+            if bindings[:parent?] &&
+                 ref_binding not in List.wrap(bindings[:lateral_join_bindings]) do
+              Ecto.Query.dynamic(field(parent_as(^ref_binding), ^attr_name))
+            else
+              Ecto.Query.dynamic(field(as(^ref_binding), ^attr_name))
+            end
+
+          Ecto.Query.dynamic(fragment("? || '|' || (? )::text", ^acc, ^value_expr))
+        end)
+      else
+        nil
+      end
+    else
+      nil
     end
   end
 


### PR DESCRIPTION
We use the Citus extension for sharding our Postgres database, which adds a requirement that any functions used within CASE or COALESCE expressions must be IMMUTABLE. Currently this means that we can't use error expressions at all because `ash_raise_error` is currently marked as STABLE.

The current `ash_raise_error` could technically be IMMUTABLE as it meets all of the requirements. However, the postgres planner will constant-fold the function call, making all expressions that use it immediately raise an exception. To prevent this we need to make the function call dependent on the row so it can't be constant-folded.

This PR works together with an AshPostgres change that adds a new function, `ash_raise_error_immutable`, which accepts a third argument that is expected to be a row-dependent value so it prevents the planner from caching. This is opt-in via `AshPostgres.Repo`, which sets a value on the repo config.

If that config value is true, then AshSql will use `ash_raise_error_immutable` instead of `ash_raise_error`, passing in a row-dependent value as the third argument. Otherwise it behaves exactly as before by calling `ash_raise_error`.

Related AshPostgres PR: https://github.com/ash-project/ash_postgres/pull/620

---

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
