### PR TITLE
fix: weird typing issue with Postgres.

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -3490,35 +3490,30 @@ defmodule AshSql.Expr do
   end
 
   defp maybe_type_expr(query, expr, bindings, embedded?, acc, type) do
-    cond do
-      type && get_path_array_type?(type) ->
-        case strip_get_path_type(expr) do
-          %GetPath{} = get_path ->
-            get_untyped_get_path_expr(query, get_path, bindings, embedded?, acc)
+    if type do
+      case strip_get_path_type(expr) do
+        %GetPath{} = get_path ->
+          get_untyped_get_path_expr(query, get_path, bindings, embedded?, acc)
 
-          _ ->
-            do_dynamic_expr(query, expr, bindings, embedded?, acc, type)
-        end
+        _ ->
+          {type, constraints} =
+            case type do
+              {:array, type} -> {{:array, type}, []}
+              {type, constraints} -> {type, constraints}
+              type -> {type, []}
+            end
 
-      type ->
-        {type, constraints} =
-          case type do
-            {:array, type} -> {{:array, type}, []}
-            {type, constraints} -> {type, constraints}
-            type -> {type, []}
-          end
-
-        do_dynamic_expr(
-          query,
-          %Ash.Query.Function.Type{arguments: [expr, type, constraints]},
-          bindings,
-          embedded?,
-          acc,
-          type
-        )
-
-      true ->
-        do_dynamic_expr(query, expr, bindings, embedded?, acc, type)
+          do_dynamic_expr(
+            query,
+            %Ash.Query.Function.Type{arguments: [expr, type, constraints]},
+            bindings,
+            embedded?,
+            acc,
+            type
+          )
+      end
+    else
+      do_dynamic_expr(query, expr, bindings, embedded?, acc, type)
     end
   end
 


### PR DESCRIPTION
This partially reverts the changes in 3cad640862c115a676ec806f77608b13c96ccf63.

I don't actually know what any of this code does, but it seems that the missing `Ash.Query.Function.Type` at the root of the expression causes weird typing issues.  The customer app does have a lot of their own types added to Postgrex using `Postgrex.Types.define/3`.

Here's what the customer was seeing:

```
     ** (Ash.Error.Unknown)
     Bread Crumbs:
       > Error returned from: App.Domain.Resource.action

     Unknown Error

     * ** (DBConnection.EncodeError) Postgrex expected an integer in -9223372036854775808..9223372036854775807, got "update_failed". Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.
       (app 0.1.0) deps/postgrex/lib/postgrex/type_module.ex:1084: App.Core.PostgrexTypes.encode_list/3
       (postgrex 0.21.1) lib/postgrex/extensions/array.ex:88: Postgrex.Extensions.Array.encode/4
       (postgrex 0.21.1) lib/postgrex/extensions/array.ex:58: Postgrex.Extensions.Array.encode/3
       (app 0.1.0) deps/postgrex/lib/postgrex/type_module.ex:1084: App.Core.PostgrexTypes.encode_params/3
       (postgrex 0.21.1) lib/postgrex/query.ex:75: DBConnection.Query.Postgrex.Query.encode/3
       (db_connection 2.8.1) lib/db_connection.ex:1446: DBConnection.encode/5
       (db_connection 2.8.1) lib/db_connection.ex:1546: DBConnection.run_prepare_execute/5
       (db_connection 2.8.1) lib/db_connection.ex:769: DBConnection.parsed_prepare_execute/5
       (db_connection 2.8.1) lib/db_connection.ex:761: DBConnection.prepare_execute/4
       (ecto_sql 3.13.2) lib/ecto/adapters/postgres/connection.ex:102: Ecto.Adapters.Postgres.Connection.prepare_execute/5
       (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1004: Ecto.Adapters.SQL.execute!/5
       (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:996: Ecto.Adapters.SQL.execute/6
       (ecto 3.13.3) lib/ecto/repo/queryable.ex:241: Ecto.Repo.Queryable.execute/4
       (ash_postgres 2.6.20) lib/data_layer.ex:1581: AshPostgres.DataLayer.update_query/4
       (ash 3.5.43) lib/ash/actions/update/bulk.ex:608: Ash.Actions.Update.Bulk.do_atomic_update/5
       (ash 3.5.43) lib/ash/data_layer/data_layer.ex:449: Ash.DataLayer.transaction/4
       (ash 3.5.43) lib/ash/actions/update/bulk.ex:276: Ash.Actions.Update.Bulk.run/6
       (app 0.1.0) deps/ash/lib/ash/code_interface.ex:1131: App.Domain.SecondResource.second_action/3
       (app 0.1.0) lib/app/domain/resource/changes/third_action_change.ex:19: anonymous fn/3 in App.Domain.Resource.Changes.ThirdActionChange.change/3
       (ash 3.5.43) lib/ash/changeset/changeset.ex:4706: anonymous fn/2 in Ash.Changeset.run_after_actions/3
```
