### PR TITLE
Revert "Support calling immutable version of `ash_raise_error`

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -2193,51 +2193,29 @@ defmodule AshSql.Expr do
         {Jason.encode!(%{exception: inspect(exception), input: Map.new(input)}), acc}
       end
 
-    dynamic_type =
+    if type do
+      # This is a type hint, if we're raising an error, we tell it what the value
+      # type *would* be in this expression so that we can return a "NULL" of that type
+      # its weird, but there isn't any other way that I can tell :)
+      validate_type!(query, type, value)
+
+      type =
+        parameterized_type(
+          bindings.sql_behaviour,
+          type,
+          [],
+          :expr
+        )
+
       if type do
-        # This is a type hint, if we're raising an error, we tell it what the value
-        # type *would* be in this expression so that we can return a "NULL" of that type
-        # its weird, but there isn't any other way that I can tell :)
-        validate_type!(query, type, value)
+        dynamic = Ecto.Query.dynamic(type(fragment("NULL"), ^type))
 
-        type =
-          parameterized_type(
-            bindings.sql_behaviour,
-            type,
-            [],
-            :expr
-          )
-
-        Ecto.Query.dynamic(type(fragment("NULL"), ^type))
+        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb, ?)", ^encoded, ^dynamic)), acc}
       else
-        nil
-      end
-
-    # A row-dependent token for immutable calls, or nil if immutable_expr_error is not opted-in to.
-    row_token = immutable_error_expr_token(query, bindings)
-
-    case {dynamic_type, row_token} do
-      {nil, nil} ->
         {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb)", ^encoded)), acc}
-
-      {dynamic_type, nil} ->
-        {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb, ?)", ^encoded, ^dynamic_type)),
-         acc}
-
-      {nil, row_token} ->
-        {Ecto.Query.dynamic(
-           fragment("ash_raise_error_immutable(?::jsonb, ?)", ^encoded, ^row_token)
-         ), acc}
-
-      {dynamic_type, row_token} ->
-        {Ecto.Query.dynamic(
-           fragment(
-             "ash_raise_error_immutable(?::jsonb, ?, ?)",
-             ^encoded,
-             ^dynamic_type,
-             ^row_token
-           )
-         ), acc}
+      end
+    else
+      {Ecto.Query.dynamic(fragment("ash_raise_error(?::jsonb)", ^encoded)), acc}
     end
   end
 
@@ -3384,65 +3362,6 @@ defmodule AshSql.Expr do
 
       true ->
         {expr, acc}
-    end
-  end
-
-  # Returns a row-dependent token to prevent constant-folding for immutable functions, or nil if
-  # the repo hasn't opted-in to immutable expr_errors.
-  defp immutable_error_expr_token(query, bindings) do
-    resource = query.__ash_bindings__.resource
-    repo = query.__ash_bindings__.sql_behaviour.repo(resource, :read)
-
-    if query.__ash_bindings__.sql_behaviour.immutable_errors?(repo) do
-      ref_binding = bindings.root_binding
-
-      pk_attr_names = Ash.Resource.Info.primary_key(resource)
-
-      attr_names =
-        case pk_attr_names do
-          [] ->
-            case Ash.Resource.Info.attributes(resource) do
-              [%{name: name} | _] -> [name]
-              _ -> []
-            end
-
-          pk ->
-            pk
-        end
-
-      if ref_binding && attr_names != [] do
-        value_exprs =
-          Enum.map(attr_names, fn attr_name ->
-            if bindings[:parent?] &&
-                 ref_binding not in List.wrap(bindings[:lateral_join_bindings]) do
-              Ecto.Query.dynamic(field(parent_as(^ref_binding), ^attr_name))
-            else
-              Ecto.Query.dynamic(field(as(^ref_binding), ^attr_name))
-            end
-          end)
-
-        row_parts =
-          value_exprs
-          |> Enum.map(&{:casted_expr, &1})
-          |> Enum.intersperse({:raw, ", "})
-
-        {%Ecto.Query.DynamicExpr{} = token, _acc} =
-          dynamic_expr(
-            query,
-            %Ash.Query.Function.Fragment{
-              embedded?: false,
-              arguments: [raw: "ROW("] ++ row_parts ++ [raw: ")"]
-            },
-            set_location(bindings, :sub_expr),
-            false
-          )
-
-        token
-      else
-        nil
-      end
-    else
-      nil
     end
   end
 

--- a/lib/implementation.ex
+++ b/lib/implementation.ex
@@ -34,7 +34,6 @@ defmodule AshSql.Implementation do
   @callback require_extension_for_citext() :: {true, String.t()} | false
   @callback strpos_function() :: String.t()
   @callback type_expr(expr :: term, type :: term) :: term
-  @callback immutable_errors?(repo :: module) :: boolean
 
   @optional_callbacks determine_types: 3
 
@@ -55,7 +54,6 @@ defmodule AshSql.Implementation do
       def ilike?, do: true
       def equals_any?, do: true
       def storage_type(_, _), do: nil
-      def immutable_errors?(_repo), do: false
 
       def type_expr(expr, type) do
         type =
@@ -78,7 +76,6 @@ defmodule AshSql.Implementation do
                      simple_join_first_aggregates: 1,
                      type_expr: 2,
                      storage_type: 2,
-                     immutable_errors?: 1,
                      list_aggregate: 1,
                      multicolumn_distinct?: 0
     end


### PR DESCRIPTION
This was refactored to be entirely self-contained within AshPostgres with this PR: https://github.com/ash-project/ash_postgres/pull/633

Originally added here in #175 last week (no AshSql release since then)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
