### PR TITLE
fix: extract_fields_from_expr returns [] 

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -2579,6 +2579,9 @@ defmodule AshSql.Aggregate do
           %{^ix => {:map, fields}} when is_list(fields) ->
             fields
 
+          take when take == %{} ->
+            all_attribute_names
+
           _ ->
             []
         end


### PR DESCRIPTION
instead of all_attribute_names when a query selects all fields ({:&, [], [ix]}) but has no take clause

In our case returned 0 instead of a calculation and broke a load

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
