### PR TITLE
fix: only merge already-computed aggregates when select? is true

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -73,7 +73,7 @@ defmodule AshSql.Aggregate do
           |> Enum.split_with(&already_added?(&1, query.__ash_bindings__, []))
 
         query =
-          if Enum.any?(already_computed_aggregates) do
+          if Enum.any?(already_computed_aggregates) && select? do
             query.__ash_bindings__.bindings
             |> Enum.filter(fn
               {_binding, %{type: :aggregate}} -> true


### PR DESCRIPTION
This fixes a bug that occurred in our application when upgrading to the latest ash packanges, in particular `ash_sql`. A PR with a [test reproducing the issue was created on ash_postgres](https://github.com/ash-project/ash_postgres/pull/653).

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
