### PR TITLE
fix: exclude :calculations from subquery select in wrap_in_subquery_for_aggregates

### DIFF
--- a/lib/calculation.ex
+++ b/lib/calculation.ex
@@ -212,6 +212,7 @@ defmodule AshSql.Calculation do
       end
 
     query = Ecto.Query.select_merge(query, ^calcs)
-    put_in(query.__ash_bindings__[:select_calculations], Map.keys(calcs))
+    select_calculations = Map.keys(calcs) |> Enum.reject(&(&1 == :calculations))
+    put_in(query.__ash_bindings__[:select_calculations], select_calculations)
   end
 end


### PR DESCRIPTION
When `wrap_in_subquery_for_aggregates` tries to select `:calculations` from the subquery, it fails with:
```
** (Ecto.QueryError) field `calculations` in struct/2 is not available in the subquery. 
Subquery only returns fields: [...]
```

This fix filters out `:calculations` from `select_calculations`, keeping only the actual calculation columns (like `__calculations____calc__0`).


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
