### PR TITLE
fix: binding error when loading aggregate

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -2562,17 +2562,15 @@ defmodule AshSql.Aggregate do
           )
       )
 
-    bindings_without_aggregates =
-      query.__ash_bindings__.bindings
-      |> Enum.reject(fn
-        {_binding, %{type: :aggregate}} -> true
-        _ -> false
-      end)
-      |> Map.new()
+    root_binding = query.__ash_bindings__.root_binding
+
+    only_root_binding = %{
+      root_binding => query.__ash_bindings__.bindings[root_binding]
+    }
 
     new_bindings =
       query.__ash_bindings__
-      |> Map.put(:bindings, bindings_without_aggregates)
+      |> Map.put(:bindings, only_root_binding)
       |> Map.delete(:__order__?)
 
     Map.put(subquery_query, :__ash_bindings__, new_bindings)


### PR DESCRIPTION
When upgrading our project to the latest ash package dependencies, I encountered a bug on an existing feature that was not previously present. The bug was introduced in a recent `ash_sql` commit.

I have used AI to create a fix for the issue, and also a test that reproduces the issue. I have verified that the test fails on `ash_sql` main and passes with the fix applied. I was not able to fully understand the fix – it's a small patch and i'm hoping it makes sense to someone with more experience in `ash_sql` than me. Otherwise, if this cannot be accepted we at least have the failing test I have created in `ash_postgres` that demonstrates the issue.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
