### PR TITLE
fix: `has_many` with `limit` and `sort` not respected in `exists` query filters

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -2373,7 +2373,7 @@ defmodule AshSql.Expr do
       AshSql.Join.related_subquery(first_relationship, query,
         filter: filter,
         filter_subquery?: true,
-        sort?: Map.get(first_relationship, :from_many?),
+        sort?: Map.get(first_relationship, :from_many?) || not is_nil(first_relationship.sort),
         start_bindings_at: 1,
         select_star?: !Map.get(first_relationship, :manual),
         in_group?: true,


### PR DESCRIPTION
Previously, the relationship limit was not being applied when using the relationship in an `exists` query. After fixing that, then the limit was being applied in the wrong place - it needs to be *inside* the exists check pre-filtering, instead of outside it.

The test for this feature is in AshPostgres, as AshSql doesn't have its own test suite https://github.com/ash-project/ash_postgres/pull/667 - this code makes that test pass.

(Claude wrote this code and I thoroughly tested it to the level that I'm comfortable putting my name on it)

Dialyzer failure is pre-existing and currently fails on main.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
