### PR TITLE
fix: use `array_agg` instead of `any_value` when `include_nil?` is true

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -1890,7 +1890,13 @@ defmodule AshSql.Aggregate do
     has_sort? = has_sort?(aggregate.query)
 
     array_agg =
-      query.__ash_bindings__.sql_behaviour.list_aggregate(aggregate.query.resource)
+      if aggregate.include_nil? do
+        # any_value() ignores NULLs by design in PostgreSQL, so we must use
+        # array_agg with [1] indexing when include_nil? is true
+        "array_agg"
+      else
+        query.__ash_bindings__.sql_behaviour.list_aggregate(aggregate.query.resource)
+      end
 
     {sorted, include_nil_filter_field, query} =
       if has_sort? || first_relationship.sort not in [nil, []] do


### PR DESCRIPTION
On PostgreSQL 16+, `any_value()` was used for `first` aggregates as an optimization. However, `any_value()` by PostgreSQL design returns "an arbitrary value from the non-null input values" - it inherently skips NULLs. This broke `include_nil?: true` for `first` aggregates.

When `include_nil?` is true, we now always use `array_agg` with `[1]` indexing, since only `array_agg` can include NULL values in the result.

Reference: https://www.postgresql.org/docs/16/functions-aggregate.html

This makes the newly-failing test in https://github.com/ash-project/ash_postgres/pull/683 pass.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
