### PR TITLE
fix: Fix CaseClauseError when filtering/sorting on doubly-nested embedded resource fields

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -3064,7 +3064,7 @@ defmodule AshSql.Expr do
 
       :bracket ->
         case first_acc do
-          {:bracket, path, nil, nil} ->
+          {:bracket, path, _, _} ->
             split_at_paths(type, constraints, rest, [
               {bracket_or_dot, [next | path], type, constraints}
               | rest_acc


### PR DESCRIPTION
`split_at_paths` accumulates path segments as it walks a `get_path` expression. The `:bracket` arm only matched `{:bracket, path, nil, nil}` — the initial empty state. After the first embedded hop the accumulator carries real type and constraint info, so no clause matched and a `CaseClauseError` was raised.

Widening the pattern to `{:bracket, path, _, _}` allows consecutive JSONB bracket accesses to keep accumulating into the same segment, which `do_get_path` already handles correctly via `jsonb_extract_path_text(col, 'key1', 'key2', ...)`.

The tests for this are in AshPostgres, as AshSql doesn't have any of its own tests - see https://github.com/ash-project/ash_postgres/pull/706

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
