### PR TITLE
fix: select name from first_relationship struct

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -830,7 +830,7 @@ defmodule AshSql.Aggregate do
          first_relationship,
          join_filters
        ) do
-    case join_filters[[first_relationship]] do
+    case join_filters[[first_relationship.name]] do
       nil ->
         {:ok, agg_root_query, acc}
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Description
When testing an aggregate which uses a join filter in a more complex relationship, it became clear that the join filter was not being applied. After a little prompting and digging with copilot's help, I was able to locate this line. It appears that the `first_relationship.name` is used in other places as it relates to `join_filters` so I'm thinking this might have just been an oversight?

Regardless, I have verified that adding this fix and using the local dependency in the project successfully addresses the issue. I would have opened an issue, but it seemed like such an easy fix I figured I would just start with a PR.

As far as a regression test, it looks like this project doesn't house a lot of tests. Should I still attempt to add a test in this project?

I did have copilot produce a minimal setup to demonstrate the issue:
<details>
  <summary>Reproduction</summary>

Resource Definitions

```elixir
defmodule Author do
  use Ash.Resource,
    domain: Blog,
    data_layer: AshPostgres.DataLayer

  postgres do
    table "authors"
    repo MyRepo
  end

  actions do
    defaults [:read, :destroy, create: :*, update: :*]
  end

  attributes do
    uuid_primary_key :id
    attribute :name, :string, allow_nil?: false
  end

  relationships do
    has_many :posts, Post
  end

  aggregates do
    # BUG: This join_filter is NOT applied
    count :published_comment_count, [:posts, :comments] do
      join_filter :posts, expr(published == true)
    end
  end
end

defmodule Post do
  use Ash.Resource,
    domain: Blog,
    data_layer: AshPostgres.DataLayer

  postgres do
    table "posts"
    repo MyRepo
  end

  actions do
    defaults [:read, :destroy, create: :*, update: :*]
  end

  attributes do
    uuid_primary_key :id
    attribute :title, :string, allow_nil?: false
    attribute :published, :boolean, allow_nil?: false, default: false
  end

  relationships do
    belongs_to :author, Author, allow_nil?: false
    has_many :comments, Comment
  end
end

defmodule Comment do
  use Ash.Resource,
    domain: Blog,
    data_layer: AshPostgres.DataLayer

  postgres do
    table "comments"
    repo MyRepo
  end

  actions do
    defaults [:read, :destroy, create: :*, update: :*]
  end

  attributes do
    uuid_primary_key :id
    attribute :body, :string, allow_nil?: false
  end

  relationships do
    belongs_to :post, Post, allow_nil?: false
  end
end
```

Test Case

```elixir
test "join_filter should filter intermediate relationship" do
  # Create author
  author = Ash.create!(Author, %{name: "Test Author"})
  
  # Create DRAFT post with 3 comments
  draft_post = Ash.create!(Post, %{title: "Draft", published: false, author_id: author.id})
  for i <- 1..3, do: Ash.create!(Comment, %{body: "Comment #{i}", post_id: draft_post.id})
  
  # Create PUBLISHED post with 2 comments
  pub_post = Ash.create!(Post, %{title: "Published", published: true, author_id: author.id})
  for i <- 1..2, do: Ash.create!(Comment, %{body: "Comment #{i}", post_id: pub_post.id})
  
  # Load aggregate
  author = 
    Author
    |> Ash.Query.filter(id == ^author.id)
    |> Ash.Query.load(:published_comment_count)
    |> Ash.read_one!()
  
  # EXPECTED: 2 (only comments from published posts)
  # ACTUAL: 5 (all comments - join_filter not applied)
  assert author.published_comment_count == 2
end
```
</details>

Very happy to add any tests that the authors and contributors would like to see. Just unclear on where.