### PR TITLE
[Fix] @dd handler for `default_dynamic_expr/6` with `%Ash.Filter{}`

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -113,6 +113,21 @@ defmodule AshSql.Expr do
     {other, acc}
   end
 
+  defp default_dynamic_expr(_query, %Filter{expression: nil}, _bindings, _embedded?, acc, _type) do
+    {true, acc}
+  end
+
+  defp default_dynamic_expr(
+         query,
+         %Filter{expression: expression},
+         bindings,
+         embedded?,
+         acc,
+         type
+       ) do
+    do_dynamic_expr(query, expression, bindings, embedded?, acc, type)
+  end
+
   defp default_dynamic_expr(query, %Not{expression: expression}, bindings, embedded?, acc, _type) do
     {new_expression, acc} =
       do_dynamic_expr(


### PR DESCRIPTION
I ran across this issue when trying to use the pinned commit for my fix for `join_filters`. I think this was potentially introduced with the update to the casting logic. When an `%Ash.Filter{}` appears nested within another expression, it isn't correctly broken down for compatibility with the SQL layer. This leads to compile time errors.

I'm not 100% sure this is the best way to address this, but it seems like it ought to be pretty close? Happy to make any changes as requested.

See https://github.com/ash-project/ash_postgres/pull/710 for the tests.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
