### PR TITLE
fix: remove unreachable code path causing warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -108,11 +108,8 @@ defmodule AshSql.MixProject do
       "main" ->
         [git: "https://github.com/ash-project/ash.git", override: true]
 
-      version when is_binary(version) ->
-        "~> #{version}"
-
       version ->
-        version
+        "~> #{version}"
     end
   end
 


### PR DESCRIPTION
Remove the unreachable code path that was causing the following warning to be shown each time the test suite was run in a project that uses ash_sql under elixir 1.20.0-rc.3-otp-28

warning: the following clause cannot match because the previous clauses already matched all possible values:

         version ->

     it attempts to match on the result of:

         System.get_env("ASH_VERSION")

     which has the already matched type:

         dynamic(nil or binary())

     where "version" was given the type:

         # type: dynamic(nil or binary())
         # from: mix.exs:114:7
         version

     type warning found at:
     │
 114 │       version ->
     │               ~
     │
     └─ mix.exs:114:15: AshSql.MixProject.ash_version/1


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
