### PR TITLE
fix: use mutate repo for queries with locks

### DIFF
--- a/lib/ash_sql.ex
+++ b/lib/ash_sql.ex
@@ -17,7 +17,7 @@ defmodule AshSql do
   def dynamic_repo(
         resource,
         sql_behaviour,
-        %struct{context: %{data_layer: %{repo: repo}}} = query
+        %_{context: %{data_layer: %{repo: repo}}} = query
       ) do
     repo || sql_behaviour.repo(resource, repo_type(query))
   end

--- a/lib/ash_sql.ex
+++ b/lib/ash_sql.ex
@@ -4,21 +4,31 @@
 
 defmodule AshSql do
   @moduledoc false
-  def dynamic_repo(resource, sql_behaviour, %{
-        __ash_bindings__: %{context: %{data_layer: %{repo: repo}}}
-      }) do
-    repo || sql_behaviour.repo(resource, :read)
+  def dynamic_repo(
+        resource,
+        sql_behaviour,
+        %{
+          __ash_bindings__: %{context: %{data_layer: %{repo: repo}}}
+        } = query
+      ) do
+    repo || sql_behaviour.repo(resource, repo_type(query))
   end
 
-  def dynamic_repo(resource, sql_behaviour, %struct{context: %{data_layer: %{repo: repo}}}) do
-    type = struct_to_repo_type(struct)
-
-    repo || sql_behaviour.repo(resource, type)
+  def dynamic_repo(
+        resource,
+        sql_behaviour,
+        %struct{context: %{data_layer: %{repo: repo}}} = query
+      ) do
+    repo || sql_behaviour.repo(resource, repo_type(query))
   end
 
-  def dynamic_repo(resource, sql_behaviour, %struct{}) do
-    sql_behaviour.repo(resource, struct_to_repo_type(struct))
+  def dynamic_repo(resource, sql_behaviour, query) do
+    sql_behaviour.repo(resource, repo_type(query))
   end
+
+  defp repo_type(%{lock: lock}) when not is_nil(lock), do: :mutate
+  defp repo_type(%struct{}), do: struct_to_repo_type(struct)
+  defp repo_type(_), do: :read
 
   def repo_opts(_repo, sql_behaviour, timeout, tenant, resource) do
     if Ash.Resource.Info.multitenancy_strategy(resource) == :context do


### PR DESCRIPTION
https://discord.com/channels/711271361523351632/1511392095917576482/1511392095917576482

I ran onto this issue via ash_oban:

ash_oban uses `Ash.Query.lock(query, :for_update)` to read records before running the trigger on the returned records. Since this is an `Ash.Query`, the logic here assumes that we can use the reader for this operation and calls the `repo` function with `:read` as the argument, instead of `:mutate`. However, in practice we cannot use `LOCK FOR UPDATE` in a read-only transaction, so postgres just borks when trying to run these against a reader.

This PR updates the logic so queries with locks use `:mutate` when getting the repo. I'm open to alternative ideas for how to handle this!

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
