### PR TITLE
Use relationship read action arguments in joins

### DIFF
--- a/lib/join.ex
+++ b/lib/join.ex
@@ -468,7 +468,7 @@ defmodule AshSql.Join do
         Ash.Query.for_read(
           query,
           read_action.name,
-          Map.get(relationship, :read_action_arguments, %{}),
+          Map.get(relationship, :read_action_argument_defaults, %{}),
           actor: context[:private][:actor],
           tenant: context[:private][:tenant]
         )

--- a/lib/join.ex
+++ b/lib/join.ex
@@ -465,7 +465,10 @@ defmodule AshSql.Join do
       if query.__validated_for_action__ == read_action.name do
         query
       else
-        Ash.Query.for_read(query, read_action.name, %{},
+        Ash.Query.for_read(
+          query,
+          read_action.name,
+          Map.get(relationship, :read_action_arguments, %{}),
           actor: context[:private][:actor],
           tenant: context[:private][:tenant]
         )

--- a/lib/join.ex
+++ b/lib/join.ex
@@ -468,7 +468,7 @@ defmodule AshSql.Join do
         Ash.Query.for_read(
           query,
           read_action.name,
-          Map.get(relationship, :read_action_argument_defaults, %{}),
+          Map.get(relationship, :read_action_arguments, %{}),
           actor: context[:private][:actor],
           tenant: context[:private][:tenant]
         )


### PR DESCRIPTION
Passes relationship `read_action_arguments` when building related queries for SQL joins.

This keeps SQL join query construction consistent with relationship loading introduced in ash-project/ash#2775. `Map.get/3` preserves compatibility with Ash versions that do not yet include the new relationship field.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
